### PR TITLE
Fix detection of `CC_SHA256_CTX` in configure.cmake

### DIFF
--- a/cmake/configure.cmake
+++ b/cmake/configure.cmake
@@ -98,9 +98,30 @@ if(HAVE_MINIX_SHA2_H)
     set(HAVE_SHA256_INIT TRUE)
 endif()
 
-if(HAVE_COMMONCRYPTO_COMMONDIGEST_H OR HAVE_SHA256_H OR HAVE_SHA2_H OR HAVE_MINIX_SHA2_H)
-    set(HAVE_CC_SHA256_CTX TRUE)
-endif()
+check_c_source_compiles("
+    #ifdef HAVE_SYS_TYPES_H
+    # include <sys/types.h>
+    #endif
+    #ifdef HAVE_COMMONCRYPTO_COMMONDIGEST_H
+    # include <CommonCrypto/CommonDigest.h>
+    #endif
+    #ifdef HAVE_SHA256_H
+    # include <sha256.h>
+    #endif
+    #ifdef HAVE_SHA2_H
+    # include <sha2.h>
+    #endif
+    #ifdef HAVE_MINIX_SHA2_H
+    # include <minix/sha2.h>
+    #endif
+    #ifdef __cplusplus
+    extern \"C\"
+    #endif
+    char SHA256_Init ();
+    int main ()
+    {
+        return SHA256_Init ();
+    }" HAVE_SHA256_INIT)
 
 check_c_source_compiles("
     #ifdef HAVE_SYS_TYPES_H


### PR DESCRIPTION
`sha256.h`, `sha2.h` and `minix/sha2.h` are not providers of
`CC_SHA256_CTX`. It seems that only
`CommonCrypto/CommonDigest.h` (Darwing MacOS) seems to provide it. This
triggers compilation errors on e.g., systems where `sha256.h` is
provided (for instance Debian/Ubuntu with libmd-dev).

This commit removes the conditional that includes `HAVE_SHA256_H`,
`HAVE_SHA2_H` and `HAVE_MINIX_SHA2`as valid providers of
`CC_SHA256_CTX`.